### PR TITLE
[FIX] odoo_updates: add the scripts module in the setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     url='https://github.com/ruiztulio/odoo_updates',
     packages=[
         'odoo_updates',
+        'odoo_updates.scripts'
     ],
     package_dir={'odoo_updates':
                  'odoo_updates'},


### PR DESCRIPTION
This fixes the error that occurred when trying to use the updatesv command 
![image](https://cloud.githubusercontent.com/assets/12100691/15307533/ac190f66-1b99-11e6-9a1c-61301e230aaf.png)

Now the command works as expected
![image](https://cloud.githubusercontent.com/assets/12100691/15307541/c50af58e-1b99-11e6-9aee-5a4f581d4a0f.png)
